### PR TITLE
DLC Database up to date October 15, 2024

### DIFF
--- a/data/id_database.json
+++ b/data/id_database.json
@@ -979,8 +979,12 @@
             "Title Updates": [],
             "Title Updates Known": [],
             "Archived": [{
-                "4b4e002500000001": "KRX1 - Classic Rock",
-                "4b4e002500000004": "KRX4   Top 40"
+				"4b4e002500000001": "KRX1 - Classic Rock",
+				"4b4e002500000002": "KRX2 – Modern Rock",
+				"4b4e002500000003": "KRX3 – Pop",
+				"4b4e002500000004": "KRX4 – Top 40",
+				"4b4e002500000005": "KRX1 - KRX5 – Classics",
+				"4b4e002500000006": "KRX6 - Mix"
         }]},
         "4b4e002e": {
             "Title Name": "Karaoke Revolution Party",
@@ -1011,9 +1015,21 @@
             "Title Updates": [],
             "Title Updates Known": [],
             "Archived": [{
-                "4b4e002e00000015": "KRXM1 - Mega Pack (1-20)",
-                "4b4e002e00000016": "KRXB1 - Bonus Pack"
+				"4b4e002e00000001": "KRX01 - Classic Rock",
+				"4b4e002e00000006": "KRX06 - Mix",
+				"4b4e002e00000007": "KRX07 - Sing and Dance",
+				"4b4e002e00000015": "KRXM1 - Mega Pack (1-20)",
+				"4b4e002e00000016": "KRXB1 - Bonus Pack"
         }]},
+        "504c0005": {
+            "Title Name": "Kingdom Under Fire: The Crusaders",
+            "Content IDs": [
+                "504c00050000001a"
+            ],
+            "Title Updates": [],
+            "Title Updates Known": [],
+            "Archived": []
+        },		
         "544d0007": {
             "Title Name": "Knights of the Temple Infernal Crusade",
             "Content IDs": [
@@ -1209,7 +1225,7 @@
             "Title Updates Known": [{
                 "3882d32fd00a969c0f657a85dcbd2e34fe150a29": "0000000100000201:NTSC+PAL 0201",
                 "4d53001700000000000000000000000000000001": "0000000100000301:NTSC+PAL 0301",
-                "4d53001700000000000000000000000000000002": "0000000100000401:NTSC+PAL 0401",
+                "dd7ff55c5981b6c1b24a5f8149c22fa2ff22e67f": "0000000100000401:NTSC+PAL 0401",
                 "a84b1da97c8597226578f282a9a8b9c755e687f9": "0000000100000601:NTSC+PAL 0601",
                 "4d53001700000000000000000000000000000003": "0000000400000504:NTSC-J South-East Asia 0504",
                 "4d53001700000000000000000000000000000004": "0000000700000207:NTSC-J Japan 0207",
@@ -1499,8 +1515,9 @@
             "Title Updates Known": [{
                 "5454009000000000000000000000000000000000": "0000000100000201:NTSC 0201"
             }],
-            "Archived": []
-        },
+            "Archived": [{
+                "5454009020051020": "Roster (2005-10-20)"
+        }]},
         "545400ae": {
             "Title Name": "NBA 2K7",
             "Content IDs": [
@@ -1570,7 +1587,7 @@
                 "eb80dee47f605d673479d892e92dad4ad42cd1ef": "0000000400010004:NTSC 10004",
                 "4d53002800000000000000000000000000000000": "0000000500020005:PAL 20005",
                 "4d53002800000000000000000000000000000001": "0000000600010006:NTSC 10006",
-		"47dd8447349a8a1b485de3723a524f469f658d22": "0000000600020006:NTSC 20006"
+                "47dd8447349a8a1b485de3723a524f469f658d22": "0000000600020006:NTSC 20006"
             }],
             "Archived": []
         },
@@ -2825,6 +2842,17 @@
             "Archived": [{
                 "5454000a00000001": "In Country"
         }]},
+        "54540087": {
+            "Title Name": "World Poker Tour",
+            "Content IDs": [],
+            "Title Updates": [
+                "0000000000000201"
+            ],
+            "Title Updates Known": [{
+                "299a23bf98e214b4711ebdf36c368579ef8b370e": "0000000000000201:NTSC 0201"
+            }],
+            "Archived": []
+        },
         "41560054": {
             "Title Name": "World Series of Poker",
             "Content IDs": [],
@@ -3012,7 +3040,7 @@
             ],
             "Title Updates Known": [{
                 "ca03aa4125324de26c7e1178e68fa97422efa822": "0000000000000302:PAL 0302",
-		"4d53005a00000000000000000000000000000000": "0000000400000104:NTSC 0104",
+                "4d53005a00000000000000000000000000000000": "0000000400000104:NTSC 0104",
                 "16a03666894efcca51b039fad65e5e5f138c1a2a": "0000000400000204:NTSC 0204"
             }],
             "Archived": [{


### PR DESCRIPTION
All Karaoke Revolution DLC found.
3 more Karaoke Revolution Party DLC found.
NBA 2K6 Roster DLC found.

Title update for World Poker Tour found, thank you Redditus!
Older title update for Mechassault 1 found, thank you darthfarther!
The only title update for Juiced found, thank you Kacey!